### PR TITLE
chore: Update deno.json exclude list

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -4,6 +4,13 @@
   "version": "0.0.13",
   "exports": "./src/mod.ts",
   "license": "MIT",
+  "exclude": [
+    ".github/",
+    "scripts/",
+    ".mise.toml",
+    "examples/",
+    "*.test.ts"
+  ],
   "tasks": {
     "test": "deno test",
     "lint": "deno lint",
@@ -86,8 +93,5 @@
       "src/"
     ],
     "exclude": []
-  },
-  "exclude": [
-    "docs/"
-  ]
+  }
 }


### PR DESCRIPTION
This PR updates the 'exclude' list in deno.json to prevent publishing unnecessary files like workflows, scripts, and local tooling config to JSR.

## Summary by Sourcery

Chores:
- Modify the exclude configuration in deno.json to prevent unnecessary files from being published to JSR