### PR TITLE
Fix: Remove unnecessary deno-lint-ignore

### DIFF
--- a/src/schemas/token.test.ts
+++ b/src/schemas/token.test.ts
@@ -15,8 +15,7 @@ describe("Resolved Token Schemas (for Lockfile)", () => {
       assertEquals(TokenPrimitiveSchema.parse("hello"), "hello");
       assertEquals(TokenPrimitiveSchema.parse(123), 123);
       const expectedBoolean = true;
-      // deno-lint-ignore no-boolean-literal-for-arguments
-      assertEquals(TokenPrimitiveSchema.parse(true), expectedBoolean);
+      assertEquals(TokenPrimitiveSchema.parse(expectedBoolean), expectedBoolean);
       assertEquals(TokenPrimitiveSchema.parse(null), null);
     });
 


### PR DESCRIPTION
Removes the  from  as it was no longer needed after refactoring.

## Summary by Sourcery

Bug Fixes:
- Removed an unnecessary deno-lint-ignore comment that was no longer needed after code refactoring