### PR TITLE
Feat: Separate Publish Workflow

### DIFF
--- a/.github/workflows/create-version-pr.yml
+++ b/.github/workflows/create-version-pr.yml
@@ -81,4 +81,4 @@ jobs:
 # Removed publish-package and create-github-release jobs from this workflow
 # They will be moved to a separate workflow triggered by tag pushes.
 # ... existing code ...
-# Ensure lines 78-131 are removed
+# This represents the end of the file

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,43 @@
+name: Publish Package and Create Release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*' # Trigger on version tags like v1.2.3
+
+permissions:
+  contents: write # Needed to create GitHub releases
+  id-token: write # Needed for OIDC authentication with JSR
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code at tag
+        uses: actions/checkout@v4
+        with:
+          # Check out the specific tag that triggered the workflow
+          ref: ${{ github.ref }}
+
+      - name: Set up Deno
+        uses: denoland/setup-deno@v1
+        # Use the version from deno.json at the tagged commit
+        # with:
+        #   deno-version: vx.x.x
+
+      - name: Run Tests
+        run: deno test
+
+      - name: Publish to JSR
+        run: npx jsr publish
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # Extract version from tag (e.g., v1.2.3 -> 1.2.3)
+          VERSION="${{ github.ref_name }}"
+          echo "Creating release for tag $VERSION"
+          gh release create "$VERSION" \
+             --generate-notes \
+             --title "Release $VERSION"


### PR DESCRIPTION
This PR separates the JSR publishing and GitHub Release creation into a new `publish.yml` workflow triggered by pushing version tags (v*.*.*). The `create-version-pr.yml` workflow now only handles determining the next version, updating `deno.json`, and creating the version bump PR. Also updates the README to reflect the new process and fixes the status badge link.

## Summary by Sourcery

Separate the release process into two distinct GitHub Actions workflows: one for version bump PRs and another for publishing and creating releases.

New Features:
- Introduce a two-step release workflow with separate version bump and publish workflows

CI:
- Create a new `publish.yml` workflow triggered by version tags
- Modify `create-version-pr.yml` to focus solely on version bump PR creation

Documentation:
- Update README to explain the new two-step release process
- Add a workflow diagram to illustrate the release process
- Update status badge to point to the CI workflow