### PR TITLE
Fix: Handle existing remote branch in version PR workflow

### DIFF
--- a/.github/workflows/create-version-pr.yml
+++ b/.github/workflows/create-version-pr.yml
@@ -83,6 +83,12 @@ jobs:
 
           # Removed tag creation
 
+          # Check if branch exists remotely and delete it if it does
+          if git ls-remote --exit-code --heads origin "$BRANCH_NAME"; then
+            echo "Branch $BRANCH_NAME already exists on remote. Deleting it."
+            git push origin --delete "$BRANCH_NAME"
+          fi
+
           echo "Pushing branch $BRANCH_NAME"
           # Push only the new branch
           git push origin $BRANCH_NAME


### PR DESCRIPTION
This PR updates the create-version-pr workflow to delete the remote version branch if it already exists before attempting to push. This prevents errors when the workflow is re-run or triggered after a partial failure.

## Summary by Sourcery

CI:
- Modify create-version-pr workflow to check for and delete existing remote branches before pushing, preventing potential errors during workflow re-runs