### PR TITLE
feat: enable auto-merge for version PR

### DIFF
--- a/.github/workflows/create-version-pr.yml
+++ b/.github/workflows/create-version-pr.yml
@@ -94,8 +94,13 @@ jobs:
           git push origin $BRANCH_NAME
 
           echo "Creating Pull Request"
-          # Use single line for gh pr create command
-          gh pr create --base main --head $BRANCH_NAME --title "chore: Prepare release $NEW_TAG_VAR" --body "Automated PR to bump version to $NEW_TAG_VAR and update deno.json. Please review and merge to trigger release."
+          # Use single line for gh pr create command, capture output
+          PR_URL=$(gh pr create --base main --head $BRANCH_NAME --title "chore: Prepare release $NEW_TAG_VAR" --body "Automated PR to bump version to $NEW_TAG_VAR and update deno.json. Please review and merge to trigger release.")
+          echo "Created PR: $PR_URL"
+
+          echo "Enabling auto-merge for PR $PR_URL"
+          gh pr merge --auto --merge "$PR_URL"
+          echo "Auto-merge enabled for $PR_URL"
 
 # Removed publish-package and create-github-release jobs from this workflow
 # They will be moved to a separate workflow triggered by tag pushes.

--- a/.github/workflows/create-version-pr.yml
+++ b/.github/workflows/create-version-pr.yml
@@ -98,6 +98,12 @@ jobs:
           PR_URL=$(gh pr create --base main --head $BRANCH_NAME --title "chore: Prepare release $NEW_TAG_VAR" --body "Automated PR to bump version to $NEW_TAG_VAR and update deno.json. Please review and merge to trigger release.")
           echo "Created PR: $PR_URL"
 
+          # Check if PR creation was successful
+          if [ -z "$PR_URL" ]; then
+            echo "Error: Failed to create pull request. Exiting."
+            exit 1
+          fi
+
           echo "Enabling auto-merge for PR $PR_URL"
           gh pr merge --auto --merge "$PR_URL"
           echo "Auto-merge enabled for $PR_URL"


### PR DESCRIPTION
Enable auto-merge for the PR created by the create-version-pr workflow.

## Summary by Sourcery

Enable auto-merge for version update pull requests to streamline the release process

CI:
- Modify create-version-pr workflow to automatically enable auto-merge for version update PRs

Chores:
- Capture PR URL when creating version update pull request